### PR TITLE
setup terraform remote backend with S3 and DynamDB; added test bucket…

### DIFF
--- a/Terraform/.terraform.lock.hcl
+++ b/Terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.36.0"
+  constraints = "5.36.0"
+  hashes = [
+    "h1:Yj/JwCmU0wF3zr7Xk4/YGxu+aNnVSROBEL/x/pu4qd0=",
+    "zh:0da8409db879b2c400a7d9ed1311ba6d9eb1374ea08779eaf0c5ad0af00ac558",
+    "zh:1b7521567e1602bfff029f88ccd2a182cdf97861c9671478660866472c3333fa",
+    "zh:1cab4e6f3a1d008d01df44a52132a90141389e77dbb4ec4f6ac1119333242ecf",
+    "zh:1df9f73595594ce8293fb21287bcacf5583ae82b9f3a8e5d704109b8cf691646",
+    "zh:2b5909268db44b6be95ff6f9dc80d5f87ca8f63ba530fe66723c5fdeb17695fc",
+    "zh:37dd731eeb0bc1b20e3ec3a0cb5eb7a730edab425058ff40f2243438acc82830",
+    "zh:3e94c76a2b607a1174d10f5712aed16cb32216ac1c91bd6f21749d61a14045ac",
+    "zh:40e6ba3184d2d3bf283a07feed8b79c1bbc537a91215cac7b3521b9ccb3e503e",
+    "zh:67e52353fea47eb97825f6eb6fddd1935e0ff3b53a8861d23a70c2babf83ae51",
+    "zh:6d2e2f390e0c7b2cd2344b1d5d6eec8a1c11cf35d19f1d6f341286f2449e9e10",
+    "zh:7005483c43926800fad5bb18e27be883dac4339edb83a8f18ccdc7edf86fafc2",
+    "zh:7073fa7ccaa9b07c2cf7b24550a90e11f4880afd5c53afd51278eff0154692a0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6d48620e526c766faec9aeb20c40a98c1810c69b6699168d725f721dfe44846",
+    "zh:e29b651b5f39324656f466cd24a54861795cc423a1b58372f4e1d2d2112d10a0",
+  ]
+}

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.36.0"
+    }
+  }
+  backend "s3" {
+    encrypt        = true
+    bucket         = "pod2-hcn-022024"
+    key            = "backend/tfstate"
+    dynamodb_table = "tfstate-lock-dynamo"
+    region         = "us-east-1"
+  }
+}
+
+
+provider "aws" {
+  region                   = "us-east-1"
+}
+
+resource "aws_s3_bucket" "testbucket" {
+  bucket = "testbucketduncan3r38r"
+}


### PR DESCRIPTION
This is the initial main.tf that sets the S3 backend in a bucket named "pod2-hcn-2024." 
The DynamoDB table "tfstate-lock-dynamo" is set for locking. 

No profile or shared credentials are included in the provider or backend blocks, so each user will need to have their temp access key, secret key, and session token in their default config profile in their local ~/.aws/credentials file in order to run Terraform for the customer's AWS account. 

The "testbucket" block was only included to make sure remote state and state locking were working, and to validate the creation of resources using the temp credentials in the default profile. This resource block can be changed to provision the S3 bucket that will be used for the static website.