### PR TITLE
changes to S3.tf to convert files from downloadable objects to web co…

### DIFF
--- a/Terraform/S3.tf
+++ b/Terraform/S3.tf
@@ -1,27 +1,34 @@
 resource "aws_s3_bucket" "website_bucket" {
   bucket = "north-health-care-website"
+  force_destroy = true
 
   tags = {
     Name = "WebsiteBucket"
   }
 }
-resource "aws_s3_object" "index_html" {
-  bucket = aws_s3_bucket.website_bucket.id
-  key    = "index.html"
-  source = "./www/index.html"  # Path to index.html relative to the root directory
+
+resource "aws_s3_object" "upload_object" {
+  for_each      = fileset("www/", "*")
+  bucket        = aws_s3_bucket.website_bucket.id
+  key           = each.value
+  source        = "www/${each.value}"
+  etag          = filemd5("www/${each.value}")
+  content_type  = "text.html"
 }
 
-resource "aws_s3_object" "error_html" {
-  bucket = aws_s3_bucket.website_bucket.id
-  key    = "error.html"
-  source = "./www/error.html"  # Path to error.html relative to the root directory
-}
 
 resource "aws_s3_bucket_public_access_block" "s3_bucket_public_access_block"{
     bucket = aws_s3_bucket.website_bucket.id
 
-    block_public_acls = false
-    block_public_policy = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "website_acl" {
+  bucket = aws_s3_bucket.website_bucket.id
+  acl    = "public-read"
 }
 
 resource "aws_s3_bucket_website_configuration" "s3_bucket" {
@@ -29,53 +36,26 @@ resource "aws_s3_bucket_website_configuration" "s3_bucket" {
 
   index_document {
     suffix = "index.html"
-
   }
 
   error_document {
     key = "error.html"
   }
-
-  
 }
 
-resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
-  bucket = aws_s3_bucket.website_bucket.id
-
-  rule {
-    object_ownership = "ObjectWriter"
-  }
-}
-
-resource "null_resource" "delay" {
-  depends_on = [aws_s3_bucket.website_bucket]
-
-  provisioner "local-exec" {
-    command = "sleep 30" # Wait for 30 seconds, adjust the duration as needed
-  }
-}
 
 resource "aws_s3_bucket_policy" "website_policy" {
   bucket = aws_s3_bucket.website_bucket.id
 
   policy = jsonencode({
-    Version   = "2012-10-17",
-    Statement = [
-      {
-        Sid       = "PublicReadGetObject",
-        Effect    = "Allow",
-        Principal = "*",
-        Action    = [
-          "s3:GetObject",
-          "s3:PutObject",   # Adding s3:PutObject action to allow uploading objects
-          "s3:PutBucketPolicy"
-        ],
-        Resource  = [
-          aws_s3_bucket.website_bucket.arn,
-          "${aws_s3_bucket.website_bucket.arn}/*"
-        ]
-      }
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Resource": ["${aws_s3_bucket.website_bucket.arn}/*"],
+        "Action": "s3:PutObject",
+        "Principal": "*",
+        }
     ]
   })
-  depends_on = [null_resource.delay]
-}
+} 


### PR DESCRIPTION
Story 6

- Added "force_destroy = true" to bucket resource, because Terraform cannot destroy a bucket with objects in it unless this parameter is set. 
- Removed resource blocks for index and error files, and instead replaced them with a single resource block that will upload any files in the "www" folder as .html files in the s3 bucket.
- Changed resource "aws_s3_bucket_public_access_block" to "false" for all 4 parameters, which is equivalent to removing the "Block all public access" in the console. 
- Added a "public-read" acl.
- Removed object owner controls after attempting every configuration with them = no change in access.
- Cleaned up bucket policy.

Requesting approval from either:
Mel, Kristin, Angel, or Jim

## Pull Request Template
-  What story or related issue is this pull request about?:
-  Describe the changes proposed in the pull request: 
- Who did you request to review the proposed changes?: 
- How soon do you need this approved?: 