### PR TITLE
addition of access control for cloudfront

### DIFF
--- a/Terraform/cloudfront.tf
+++ b/Terraform/cloudfront.tf
@@ -5,13 +5,13 @@ locals {
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     domain_name              = aws_s3_bucket.website_bucket.bucket_regional_domain_name
-    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_access_control_id = aws_cloudfront_origin_access_control.OAC.id
     origin_id                = local.s3_origin_id
   }
 
   enabled             = true
   is_ipv6_enabled     = true
-  comment             = "Some comment"
+  comment             = "Origin S3 bucket:website_bucket, index.html"
   default_root_object = "index.html"
 
 

--- a/Terraform/cloudfront_access_control.tf
+++ b/Terraform/cloudfront_access_control.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_origin_access_control" "OAC" {
+  name                              = "nch_website_access_control"
+  description                       = "S3 static website cloudfront policy"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}


### PR DESCRIPTION
Story 8

- added missing resource to cloudfront:  **resource "aws_cloudfront_origin_access_control"**
- added comment to cloudfront origin
- added reference to newly added resource in the "aws_cloudfront_distribution" block

Who did you request to review the proposed changes?:
Mel, Angel, Kristin, Corey
 
How soon do you need this approved?: 
However soon people need to continue remainder of work